### PR TITLE
feat: ignore nix development files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 /target
+
+# ignore nix dev tools
+.direnv/
+.envrc
+flake.nix
+flake.lock


### PR DESCRIPTION
For developing in nixos I use nix-direnv. To make sure these files aren't in upstream I added them to the gitignore
