### PR TITLE
fix: disable doctests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ rocket = "0.5.1"
 serde = { version = "1.0.208", features = ["derive"] }
 tera = "1.20.0"
 
+[lib]
+doctest = false
+
 [lints.clippy]
 missing_panics_doc = "deny"
 missing_errors_doc = "deny"


### PR DESCRIPTION
Doctests cause CI to fail, because the code snippets inside doc comments are not 100% valid rust. Since the current program structure is still very mallable I've decided to disable them for now.